### PR TITLE
client: Allow for top-level traversals to be passed in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 npm-debug.log
 coverage
+package-lock.json

--- a/index.d.ts
+++ b/index.d.ts
@@ -51,7 +51,7 @@ declare module 'be-hippo' {
   }
 
   export class Client {
-    constructor(apiRoot: string, options?: ClientOptions);
+    constructor(apiRoot: KeyValuePair | string, options?: ClientOptions);
 
     walk(...shortNames: Connection[]): Promise<Resource>;
 

--- a/src/uritemplate.js
+++ b/src/uritemplate.js
@@ -4,7 +4,7 @@ const VARIABLE_CHAR_CLASS = Uri.CHAR_CLASSES.ALPHA + Uri.CHAR_CLASSES.DIGIT + '_
 const ALL = Uri.CHAR_CLASSES.RESERVED + Uri.CHAR_CLASSES.UNRESERVED;
 const VAR_CHAR = '(?:(?:[' + VARIABLE_CHAR_CLASS + ']|%[a-fA-F0-9][a-fA-F0-9])+)';
 const RESERVED = '(?:[' + ALL + ']|%[a-fA-F0-9][a-fA-F0-9])';
-const UNRESERVED = '(?:[#{' + UNRESERVED + '}]|%[a-fA-F0-9][a-fA-F0-9])'; // eslint-disable-line no-use-before-define
+const UNRESERVED = '(?:[#{' + Uri.CHAR_CLASSES.UNRESERVED + '}]|%[a-fA-F0-9][a-fA-F0-9])';
 const VARIABLE = '(?:' + VAR_CHAR + '(?:\\.?' + VAR_CHAR + ')*)';
 const VARSPEC = '(?:(' + VARIABLE + ')(\\*|:\\d+)?)';
 const OPERATOR = '+#./;?&=,!@|';


### PR DESCRIPTION
Allows for an object of traversals (map of `shortname` -> `uri template`) be passed as the api root. In this mode, it treats that as the walk of the top-level root resource and all passed sub-resources.

This _does_ mean that the multiple subname walking behavior (`client.walk('user', 'comments')`) will not work, as the passed object assumes all resources only define a link to `self`. Given that we use this very infrequently, it seems like a fair compromise to keep the overall behavior simple. This can be worked around by ensuring that all potential shortnames walked are defined as part of the top-level api description passed on initialization.